### PR TITLE
Compare branch-A-Assertions and master

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "java.project.sourcePaths": [
         "src/main/java",
         "src/main/resources"
-    ]
+    ],
+    "java.configuration.updateBuildConfiguration": "interactive"
 }

--- a/src/main/java/commands/ByeCommand.java
+++ b/src/main/java/commands/ByeCommand.java
@@ -2,7 +2,6 @@ package commands;
 
 import storage.StorageManager;
 import tasklist.TaskList;
-import tasks.Task;
 
 /**
  * Represents a command to exit the application.

--- a/src/main/java/storage/StorageManager.java
+++ b/src/main/java/storage/StorageManager.java
@@ -44,6 +44,7 @@ public class StorageManager {
      * @param tasks The task list to be saved.
      */
     public void save(TaskList tasks) {
+        assert taskSaveLocation != null : "Save path should not be empty";
         StringBuilder sb = new StringBuilder();
         String serializedTask;
         for (int i = 0; i < tasks.getSize(); i++) {
@@ -65,6 +66,7 @@ public class StorageManager {
      */
 
     public TaskList load() {
+        assert taskSaveLocation != null : "Save path should not be empty";
         File dataFile = new File(this.taskSaveLocation);
         List<Task> tasks = new ArrayList<>();
 

--- a/src/main/java/storage/TaskSerializer.java
+++ b/src/main/java/storage/TaskSerializer.java
@@ -21,6 +21,8 @@ public class TaskSerializer {
      * @return A string representing the serialized tasks.
      */
     public static String serialize(Task t) {
+        assert t != null : "Task should not be null";
+        
         String[] taskFields = {"", "", "", "", ""};
         taskFields[1] = t.getStatus() ? "1" : "0";
         taskFields[2] = t.getDescription();

--- a/src/main/java/tasklist/TaskList.java
+++ b/src/main/java/tasklist/TaskList.java
@@ -57,6 +57,7 @@ public class TaskList {
             throw new CalException("Invalid task number!");
         }
         Task t = tasks.get(taskNum - 1);
+        assert t != null : "Task should not be null";
         t.setStatus(true);
         return t;
     }
@@ -73,6 +74,7 @@ public class TaskList {
             throw new CalException("Invalid task number!");
         }
         Task t = tasks.get(taskNum - 1);
+        assert t != null : "Task should not be null";
         t.setStatus(false);
         return t;
     }


### PR DESCRIPTION
Adding assertions to StorageManager and TaskSerialiser

TaskSerialiser lacks assertions to ensure that task exist in order to serialise task into string and parse string back into task. StorageManager lacks assertions to ensure that save path exists before attempting to save to directory and load from directory.

Assert statements are added to the TaskSerializer class to check for null inputs, as well as StorageManager class to check for empty save path.

Adding assertions allows us to catch potential issues early in the development process, reducing the likelihood of introducing bugs into the codebase.